### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup_args = {
     'license': 'BSD 3-Clause',
     'install_requires': [
         'pynwb>=1.3.0',
-        'numpy<1.19.4',
+        'numpy>=1.22.0',
         'h5py',
     ],
     'packages': find_packages('src/pynwb'),


### PR DESCRIPTION
When installing `ndx-photometry` with `neuroconv` I get the following error:

```
    neuroconv 0.2.4 requires numpy>=1.22.0; python_version >= "3.8", but you have numpy 1.19.3 which is incompatible.
    ndx-photometry 0.1.1 depends on numpy<1.19.4
```

I updated the numpy package version to numpy>=1.22.0.