### PR TITLE
Change wavelengths definition and add optical filter device

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ fibers_table.add_row(
 # Create an Excitation Sources table, and a one (or many) excitation source
 excitationsources_table = ExcitationSourcesTable(description="excitation sources table")
 excitationsources_table.add_row(
-    peak_wavelength=700.0,
+    excitation_wavelength=700.0,
     source_type="laser",
 )
 
 # Create a Photodetectors table, and add one (or many) photodetector
 photodetectors_table = PhotodetectorsTable(description="photodetectors table")
 photodetectors_table.add_row(
-    peak_wavelength=500.0,
+    detected_wavelength=500.0,
     type="PMT",
     gain=100.0
 )
@@ -79,8 +79,6 @@ fluorophores_table.add_row(
     label="dlight",
     location="VTA",
     coordinates=(3.0,2.0,1.0),
-    excitation_peak_wavelength=700.0,
-    emission_peak_wavelength=500.0
 )
 
 # Here we add the metadata tables to the metadata section

--- a/src/pynwb/tests/integration/test_photometry.py
+++ b/src/pynwb/tests/integration/test_photometry.py
@@ -75,7 +75,7 @@ class TestIntegrationRoundtrip(TestCase):
         )
 
         excitationsources_table.add_row(
-            peak_wavelength=700.0,
+            excitation_wavelength=700.0,
             source_type="laser",
             commanded_voltage=commandedvoltage_series,
         )
@@ -83,7 +83,7 @@ class TestIntegrationRoundtrip(TestCase):
         photodetectors_table = PhotodetectorsTable(
             description="photodetectors table"
         )
-        photodetectors_table.add_row(peak_wavelength=500.0, type="PMT", gain=100.0)
+        photodetectors_table.add_row(detected_wavelength=500.0, type="PMT", gain=100.0)
 
         fluorophores_table = FluorophoresTable(
             description='fluorophores'

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -379,6 +379,39 @@ def main():
         ],
     )
 
+    optical_filter = NWBGroupSpec(
+        neurodata_type_def="OpticalFilter",
+        neurodata_type_inc="Device",
+        doc="Extends Device to hold a Optical Filter",
+        datasets=[
+            NWBDatasetSpec(
+                name="peak_wavelength",
+                doc="wavelength that the filter is designed to pass or reflect",
+                dtype="float",
+                attributes=[
+                    NWBAttributeSpec(
+                        name="unit", doc="wavelength unit", value="nanometers", dtype="text"
+                    )
+                ],
+            ),
+            NWBDatasetSpec(
+                name="bandwidth",
+                doc="width of the wavelength range that the filter allows to pass through or blocks",
+                dtype="float",
+                attributes=[
+                    NWBAttributeSpec(
+                        name="unit", doc="wavelength unit", value="nanometers", dtype="text"
+                    )
+                ],
+            ),
+            NWBAttributeSpec(
+                name="filter_type",
+                doc="type of filter (e.g., 'Excitation', 'Emission', 'Bandpass', 'Longpass', 'Shortpass')",
+                dtype="text",
+            ),
+        ],
+    )
+
     # Add all new data types to this list
     new_data_types = [
         fibers_table,
@@ -390,6 +423,7 @@ def main():
         commandedvoltage_series,
         multi_commanded_voltage,
         fiber_photometry,
+        optical_filter,
     ]
 
     # export the spec to yaml files in the spec folder

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -87,14 +87,6 @@ def main():
                 neurodata_type_inc="VectorData",
                 quantity="?",
             ),
-            NWBDatasetSpec(
-                name="dichroic_model_number",
-                doc="dichroic model number",
-                dtype="text",
-                shape=(None,),
-                neurodata_type_inc="VectorData",
-                quantity="?",
-            ),
         ],
     )
 
@@ -409,6 +401,12 @@ def main():
                 doc="type of filter (e.g., 'Excitation', 'Emission', 'Bandpass', 'Longpass', 'Shortpass')",
                 dtype="text",
             ),
+            NWBAttributeSpec(
+                name="model",
+                doc="model of the optical filter",
+                dtype="text",
+                quantity="?",
+            ),
         ],
     )
 
@@ -487,6 +485,12 @@ def main():
                         dtype="text",
                     )
                 ],
+            ),
+            NWBAttributeSpec(
+                name="model",
+                doc="model of the dichroic mirror",
+                dtype="text",
+                quantity="?",
             ),
         ],
     )

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -412,6 +412,85 @@ def main():
         ],
     )
 
+    dichroic_mirror = NWBGroupSpec(
+        neurodata_type_def="DichroicMirror",
+        neurodata_type_inc="Device",
+        doc="Extends Device to hold a Dichroic Mirror",
+        datasets=[
+            NWBDatasetSpec(
+                name="cut_on_wavelength",
+                doc="wavelength at which the mirror starts to transmit light more than reflect",
+                dtype="float",
+                attributes=[
+                    NWBAttributeSpec(
+                        name="unit",
+                        doc="wavelength unit",
+                        value="nanometers",
+                        dtype="text",
+                    )
+                ],
+            ),
+            NWBDatasetSpec(
+                name="cut_off_wavelength",
+                doc="wavelength at which transmission shifts back to reflection, for mirrors with complex transmission spectra",
+                dtype="float",
+                quantity="?",
+                attributes=[
+                    NWBAttributeSpec(
+                        name="unit",
+                        doc="wavelength unit",
+                        value="nanometers",
+                        dtype="text",
+                    )
+                ],
+            ),
+            NWBDatasetSpec(
+                name="reflection_bandwidth",
+                doc="The range of wavelengths that are primarily reflected. The start and end wavelengths needs to be specified.",
+                dtype="float",
+                quantity="?",
+                shape=(2,),
+                attributes=[
+                    NWBAttributeSpec(
+                        name="unit",
+                        doc="wavelength unit",
+                        value="nanometers",
+                        dtype="text",
+                    )
+                ],
+            ),
+            NWBDatasetSpec(
+                name="transmission_bandwidth",
+                doc="The range of wavelengths that are primarily transmitted. The start and end wavelengths needs to be specified.",
+                dtype="float",
+                quantity="?",
+                shape=(2,),
+                attributes=[
+                    NWBAttributeSpec(
+                        name="unit",
+                        doc="wavelength unit",
+                        value="nanometers",
+                        dtype="text",
+                    )
+                ],
+            ),
+            NWBDatasetSpec(
+                name="angle_of_incidence",
+                doc="intended angle at which light strikes the mirror",
+                dtype="float",
+                quantity="?",
+                attributes=[
+                    NWBAttributeSpec(
+                        name="unit",
+                        doc="angle unit",
+                        value="degrees",
+                        dtype="text",
+                    )
+                ],
+            ),
+        ],
+    )
+
     # Add all new data types to this list
     new_data_types = [
         fibers_table,
@@ -424,6 +503,7 @@ def main():
         multi_commanded_voltage,
         fiber_photometry,
         optical_filter,
+        dichroic_mirror,
     ]
 
     # export the spec to yaml files in the spec folder

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -105,8 +105,8 @@ def main():
         doc="Extends DynamicTable to hold various Photodetectors",
         datasets=[
             NWBDatasetSpec(
-                name="peak_wavelength",
-                doc="peak wavelength of photodetector",
+                name="detected_wavelength",
+                doc="wavelength detected by photodetector",
                 dtype="float",
                 shape=(None,),
                 neurodata_type_inc="VectorData",
@@ -150,8 +150,8 @@ def main():
         doc="Extends DynamicTable to hold various Excitation Sources",
         datasets=[
             NWBDatasetSpec(
-                name="peak_wavelength",
-                doc="peak wavelength of the excitation source",
+                name="excitation_wavelength",
+                doc="wavelength of the excitation source",
                 dtype="float",
                 shape=(None,),
                 neurodata_type_inc="VectorData",
@@ -279,30 +279,6 @@ def main():
                 shape=(None, 3),
                 neurodata_type_inc="VectorData",
                 quantity="?",
-            ),
-            NWBDatasetSpec(
-                name="emission_peak_wavelength",
-                doc="Peak wavelength of emission of the fluorophore, in nanometers.",
-                dtype="float",
-                shape=(None,),
-                neurodata_type_inc="VectorData",
-                attributes=[
-                    NWBAttributeSpec(
-                        name="unit", doc="wavelength unit", value="nanometers", dtype="text"
-                    )
-                ],
-            ),
-            NWBDatasetSpec(
-                name="excitation_peak_wavelength",
-                doc="Peak wavelength of excitation of the fluorophore, in nanometers.",
-                dtype="float",
-                shape=(None,),
-                neurodata_type_inc="VectorData",
-                attributes=[
-                    NWBAttributeSpec(
-                        name="unit", doc="wavelength unit", value="nanometers", dtype="text"
-                    )
-                ],
             ),
         ],
     )


### PR DESCRIPTION
## peak wavelength issue 

1. `peak_wavelength` for the `photodetector` can be confusing: does it mean the peak of the responsivity curve of the photodetector or the wavelength of interest (the one that is usually reported in the papers and filtered with an optical filter before hitting the detector)? I would store the actual detected wavelength and call the field: `detected_wavelength`
![image](https://github.com/catalystneuro/ndx-photometry/assets/55453048/7a5b40dd-a68f-4419-b5c6-ce33cb6bab90)

2.  `peak_wavelength` for `excitation_sources` it's fine, but I would change to `excitation_wavelength` for simplicity.
![image](https://github.com/catalystneuro/ndx-photometry/assets/55453048/f36fdb80-538d-46de-8fdd-b1437f8e9112)

3. finally, the `emission_peak_wavelength` and the `excitation_peak_wavelength` of the fluorophore are characteristics of the protein’s spectrum in a specific configuration, e.g. GCaMP6 bound to Ca2+ or independent from Ca2+.
![image](https://github.com/catalystneuro/ndx-photometry/assets/55453048/9e783556-d34b-4a46-99a6-640ee50c983e)

The important information for these experiments to be reproduced are:
- excitation wavelength of the source with relative optical filter (peak/bandwidth)
- emission wavelength recorded with relative optical filter (peak/bandwidth)
- model of the excitation source, so you can retrieve the spectrum from the datasheet
- model of the photodetector, so you can retrieve the responsivity curve from the datasheet 
- the fluorophore notation, so you can retrieve the relative emission and excitation spectra from [databases](https://www.fpbase.org/ ).
- also important the dichroic mirror device
![image](https://github.com/catalystneuro/ndx-photometry/assets/55453048/18806721-dce2-4df3-9d75-181aee422e88)
## TODOs for this PR:

- [x] change  `peak_wavelength` for the `photodetector` to `detected_wavelength`
- [x] change  `peak_wavelength` for the `excitation_sources` to `excitation_wavelength`
- [x] remove `emission_peak_wavelength` and the `excitation_peak_wavelength` of the `fluorophore` (to avoid confusion)
- [x] add `OpticalFilter` (Device) (this could be designed to match the same device for ndx-microscopy (link to https://github.com/catalystneuro/ndx-microscopy/issues/6). It should be described by 
    - filter_type: A string indicating the type of filter (e.g., "Excitation", "Emission", "Bandpass", "Longpass", "Shortpass"). This field helps users understand the filter's intended use in the optical path.
    - peak_wavelength: The central wavelength (in nm) that the filter is designed to pass or reflect, relevant for bandpass and notch filters.
    - bandwidth: The width of the wavelength range (in nm) that the filter allows to pass through (for bandpass filters) or blocks (for notch filters).
- [ ] add optional field for reference the `OpticalFilter` in both `photodetector` and `excitation_sources` as an extra column
- [x] add DichroicMirror (Device) (also designed to be shared with ndx-microscopy). The following are the fields to be included in this device: 
    - cut_on_wavelength: The wavelength (in nm) at which the mirror starts to transmit light more than reflect. This marks the boundary between reflection and transmission.
    - cut_off_wavelength: An optional field, if distinct from the CutOnWavelength, that can specify the wavelength at which transmission shifts back to reflection, for mirrors with complex transmission spectra.
    - reflection_bandwidth: The range of wavelengths (in nm) that are primarily reflected. This can be represented as a tuple or list if you want to specify the start and end wavelengths.
    - transmission_bandwidth: The range of wavelengths (in nm) that are primarily transmitted. Like ReflectionBandwidth, this can also be a tuple or list.
    - angle_of_incidence: The intended angle (in degrees) at which light strikes the mirror, as this can significantly affect its performance.
- [ ] add optional field for reference the `DichroicMirror` in the `fibers_table`
- [ ] implements tests